### PR TITLE
Add missing mackup apps / update PHPStorm support

### DIFF
--- a/apps/apple-music/include-from.rsync
+++ b/apps/apple-music/include-from.rsync
@@ -1,0 +1,7 @@
+Library
+Library/Music
+Library/Music/Scripts
+Library/Music/Scripts/**
+Library/Preferences
+Library/Preferences/com.apple.Music.eq.plist
+Library/Preferences/com.apple.Music.plist

--- a/apps/bitbar/include-from.rsync
+++ b/apps/bitbar/include-from.rsync
@@ -1,0 +1,4 @@
+Library
+Library/Preferences
+Library/Preferences/com.matryer.BitBar.plist
+Library/Preferences/com.matryer.BitBar.plist/**

--- a/apps/brave/include-from.rsync
+++ b/apps/brave/include-from.rsync
@@ -1,0 +1,7 @@
+Library
+Library/Application Support
+Library/Application Support/BraveSoftware
+Library/Application Support/BraveSoftware/Brave-Browser
+Library/Application Support/BraveSoftware/Brave-Browser/Default
+Library/Application Support/BraveSoftware/Brave-Browser/Default/Preferences
+Library/Application Support/BraveSoftware/Brave-Browser/Default/Preferences/**

--- a/apps/bump/include-from.rsync
+++ b/apps/bump/include-from.rsync
@@ -1,0 +1,2 @@
+.bump.json
+.bump.json/**

--- a/apps/calibre/include-from.rsync
+++ b/apps/calibre/include-from.rsync
@@ -1,0 +1,6 @@
+Library
+Library/Preferences
+Library/Preferences/calibre
+Library/Preferences/calibre/**
+calibre
+calibre/**

--- a/apps/clashx/include-from.rsync
+++ b/apps/clashx/include-from.rsync
@@ -1,0 +1,2 @@
+clash
+clash/**

--- a/apps/doom-emacs/include-from.rsync
+++ b/apps/doom-emacs/include-from.rsync
@@ -1,0 +1,2 @@
+.doom.d
+.doom.d/**

--- a/apps/finicky/include-from.rsync
+++ b/apps/finicky/include-from.rsync
@@ -1,0 +1,2 @@
+.finicky.js
+.finicky.js/**

--- a/apps/goodsync/include-from.rsync
+++ b/apps/goodsync/include-from.rsync
@@ -1,0 +1,2 @@
+.goodsync
+.goodsync/**

--- a/apps/hocus-focus/include-from.rsync
+++ b/apps/hocus-focus/include-from.rsync
@@ -1,0 +1,11 @@
+Library
+Library/Preferences
+Library/Preferences/com.uglyapps.HocusFocus.plist
+Library/Preferences/com.uglyapps.HocusFocus.plist/**
+Library/Application Support
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db/**
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db-shm
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db-shm/**
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db-wal
+Library/Application Support/com.uglyapps.HocusFocusHocusFocus.db-wal/**

--- a/apps/istat-menus/include-from.rsync
+++ b/apps/istat-menus/include-from.rsync
@@ -1,0 +1,10 @@
+Library
+Library/Preferences
+Library/Preferences/com.bjango.istatmenus.plist
+Library/Preferences/com.bjango.istatmenus.plist/**
+Library/Preferences/com.bjango.istatmenus.status.plist
+Library/Preferences/com.bjango.istatmenus.status.plist/**
+Library/Preferences/com.bjango.istatmenus5.extras.plist
+Library/Preferences/com.bjango.istatmenus5.extras.plist/**
+Library/Preferences/com.bjango.istatmenus6.extras.plist
+Library/Preferences/com.bjango.istatmenus6.extras.plist/**

--- a/apps/joplin/include-from.rsync
+++ b/apps/joplin/include-from.rsync
@@ -1,0 +1,5 @@
+joplin-desktop
+joplin-desktop/userchrome.css
+joplin-desktop/userchrome.css/**
+joplin-desktop/userstyle.css
+joplin-desktop/userstyle.css/**

--- a/apps/jsbeautifier/include-from.rsync
+++ b/apps/jsbeautifier/include-from.rsync
@@ -1,0 +1,2 @@
+.jsbeautifyrc
+.jsbeautifyrc/**

--- a/apps/kaggle/include-from.rsync
+++ b/apps/kaggle/include-from.rsync
@@ -1,0 +1,3 @@
+.kaggle
+.kaggle/kaggle.json
+.kaggle/kaggle.json/**

--- a/apps/mako/include-from.rsync
+++ b/apps/mako/include-from.rsync
@@ -1,0 +1,3 @@
+mako
+mako/config
+mako/config/**

--- a/apps/mitmproxy/include-from.rsync
+++ b/apps/mitmproxy/include-from.rsync
@@ -1,0 +1,3 @@
+.mitmproxy
+.mitmproxy/config.yaml
+.mitmproxy/config.yaml/**

--- a/apps/mkcert/include-from.rsync
+++ b/apps/mkcert/include-from.rsync
@@ -1,0 +1,4 @@
+Library
+Library/Application Support
+Library/Application Support/mkcert
+Library/Application Support/mkcert/**

--- a/apps/nosqlbooster-for-mongodb/include-from.rsync
+++ b/apps/nosqlbooster-for-mongodb/include-from.rsync
@@ -1,0 +1,3 @@
+Documents
+Documents/NoSQLBooster
+Documents/NoSQLBooster/**

--- a/apps/nushell/include-from.rsync
+++ b/apps/nushell/include-from.rsync
@@ -1,0 +1,3 @@
+nu
+nu/config.toml
+nu/config.toml/**

--- a/apps/phpstorm/include-from.rsync
+++ b/apps/phpstorm/include-from.rsync
@@ -1,5 +1,8 @@
 Library
 Library/Application Support
+Library/Application Support/JetBrains
+Library/Application Support/JetBrains/PhpStorm2020.1
+Library/Application Support/JetBrains/PhpStorm2020.1/**
 Library/Application Support/PhpStorm2016.1
 Library/Application Support/PhpStorm2016.1/**
 Library/Application Support/PhpStorm2016.2
@@ -22,6 +25,8 @@ Library/Application Support/PhpStorm2019.1
 Library/Application Support/PhpStorm2019.1/**
 Library/Application Support/PhpStorm2019.2
 Library/Application Support/PhpStorm2019.2/**
+Library/Application Support/PhpStorm2019.3
+Library/Application Support/PhpStorm2019.3/**
 Library/Application Support/WebIde100
 Library/Application Support/WebIde100/**
 Library/Application Support/WebIde60
@@ -59,6 +64,8 @@ Library/Preferences/PhpStorm2019.1
 Library/Preferences/PhpStorm2019.1/**
 Library/Preferences/PhpStorm2019.2
 Library/Preferences/PhpStorm2019.2/**
+Library/Preferences/PhpStorm2019.3
+Library/Preferences/PhpStorm2019.3/**
 Library/Preferences/WebIde100
 Library/Preferences/WebIde100/**
 Library/Preferences/WebIde60

--- a/apps/poetry/include-from.rsync
+++ b/apps/poetry/include-from.rsync
@@ -1,0 +1,5 @@
+Library
+Library/Application Support
+Library/Application Support/pypoetry
+Library/Application Support/pypoetry/config.cfg
+Library/Application Support/pypoetry/config.cfg/**

--- a/apps/powerline/include-from.rsync
+++ b/apps/powerline/include-from.rsync
@@ -1,0 +1,9 @@
+powerline
+powerline/config.json
+powerline/config.json/**
+powerline/colors.json
+powerline/colors.json/**
+powerline/themes
+powerline/themes/**
+powerline/colorschemes
+powerline/colorschemes/**

--- a/apps/quitter/include-from.rsync
+++ b/apps/quitter/include-from.rsync
@@ -1,0 +1,4 @@
+Library
+Library/Preferences
+Library/Preferences/com.marcoarment.quitter.plist
+Library/Preferences/com.marcoarment.quitter.plist/**

--- a/apps/rclone/include-from.rsync
+++ b/apps/rclone/include-from.rsync
@@ -1,0 +1,2 @@
+rclone
+rclone/**

--- a/apps/rectangle/include-from.rsync
+++ b/apps/rectangle/include-from.rsync
@@ -1,0 +1,4 @@
+Library
+Library/Preferences
+Library/Preferences/com.knollsoft.Rectangle.plist
+Library/Preferences/com.knollsoft.Rectangle.plist/**

--- a/apps/ripgrep/include-from.rsync
+++ b/apps/ripgrep/include-from.rsync
@@ -1,0 +1,2 @@
+.ripgreprc
+.ripgreprc/**

--- a/apps/starship/include-from.rsync
+++ b/apps/starship/include-from.rsync
@@ -1,0 +1,3 @@
+.config
+.config/starship.toml
+.config/starship.toml/**

--- a/apps/swaywm/include-from.rsync
+++ b/apps/swaywm/include-from.rsync
@@ -1,0 +1,2 @@
+sway
+sway/**

--- a/apps/termite/include-from.rsync
+++ b/apps/termite/include-from.rsync
@@ -1,0 +1,3 @@
+termite
+termite/config
+termite/config/**

--- a/apps/tripmode/include-from.rsync
+++ b/apps/tripmode/include-from.rsync
@@ -1,0 +1,4 @@
+Library
+Library/Application Support
+Library/Application Support/TripMode
+Library/Application Support/TripMode/**

--- a/apps/waybar/include-from.rsync
+++ b/apps/waybar/include-from.rsync
@@ -1,0 +1,2 @@
+waybar
+waybar/**

--- a/apps/yarn/include-from.rsync
+++ b/apps/yarn/include-from.rsync
@@ -1,0 +1,2 @@
+.yarnrc
+.yarnrc/**


### PR DESCRIPTION
This adds all missing apps from the latest mackup version, as well as updating PHPStorm support for both 2019.3 and 2020.1.